### PR TITLE
Fixes biofoam typo.

### DIFF
--- a/modules/items/traumakit/traumakit_biofoam.zsc
+++ b/modules/items/traumakit/traumakit_biofoam.zsc
@@ -1,7 +1,7 @@
 extend class UaS_TraumaKit {
 	void HandleBioFoam() {
 		statusMessage = statusmessage.."\cjBiofoam\n";
-		statusMessage = statusmessage.."\cuAbsorbant antispetic flesh-analogue.\n";
+		statusMessage = statusmessage.."\cuAbsorbent antiseptic flesh-analogue.\n";
 		statusMessage = statusmessage.."Biofoam remaining: \cy"..weaponstatus[TKS_BIOFOAM].."\n\n";
 		if (!currentWound) { return; }
 		if (currentWound.open <= 0) { return; }


### PR DESCRIPTION
* Changes 'antispetic' to 'antiseptic'.
* Changes 'absorbant' to 'absorbent'; technically both are correct but absorbent is the more commonly-used term, from my research.