### PR TITLE
Deathfade: Fix wrong user's cvar being checked.

### DIFF
--- a/deathfade/module/deathfade.zsc
+++ b/deathfade/module/deathfade.zsc
@@ -1,14 +1,4 @@
 class UaS_DeathFade_Bootstrap : EventHandler {
-	transient cvar deathfade;
-
-	override void OnRegister() {
-		for (int i = 0; i < MAXPLAYERS; i++) {
-			if (!playeringame[i]) { continue; }
-			deathfade = CVar.GetCVar("UaS_DeathFade", players[i]);
-			if (!deathfade) { console.printf("CVar UaS_DeathFade ignored in standalone mode"); }
-		}
-	}
-
 	override void WorldTick() {
 		for (int i = 0; i < MAXPLAYERS; i++) {
 			if (!playeringame[i]) { continue; }
@@ -17,7 +7,7 @@ class UaS_DeathFade_Bootstrap : EventHandler {
 	}
 
 	bool DoDeathFade(int pnum) {
-		if (!deathfade) { deathfade = CVar.GetCVar("UaS_DeathFade", players[pnum]); }
+		let deathfade = CVar.GetCVar("UaS_DeathFade", players[pnum]);
 		if (!deathfade) { return true; }
 		return deathfade.GetBool();
 	}
@@ -28,7 +18,7 @@ class UaS_DeathFade_Bootstrap : EventHandler {
 	}
 
 	void Deathfade_Bootstrap(int pnum, bool activate) {
-		Shader.SetEnabled(players[pnum].mo.player, "deathfade", activate);
+		Shader.SetEnabled(players[pnum], "deathfade", activate);
 		if (!activate) { return; }
 		UaS_DeathFader df = new("UaS_DeathFader");
 		df.plr = HDPlayerPawn(players[pnum].mo);


### PR DESCRIPTION
Fixes deathfade being applied to all players when the first player to die has it enabled.