### PR TITLE
Scarcity: Don't remove/replace special things

### DIFF
--- a/scarcity/module/scarcity_remover.zsc
+++ b/scarcity/module/scarcity_remover.zsc
@@ -5,7 +5,10 @@ extend class UaS_Scarcity_Handler {
 		Actor nextThing;
 		let thingCounter = ThinkerIterator.Create(CheckClass, Thinker.STAT_DEFAULT);
 		while(nextThing = Actor(thingCounter.Next(true))) {
-			if(nextThing.GetClassName() == CheckClass) { thingArray.Push(nextThing); }
+			if(
+				nextThing.GetClassName() == CheckClass
+				&& nextThing.special == 0
+			) { thingArray.Push(nextThing); }
 		}
 
 		int originalcount = thingArray.Size();


### PR DESCRIPTION
Prevents soft-locks caused by actors essential to progression being removed or being replaced without the special being copied over.