### PR TITLE
Strip leading forward slash from TEXTUREs patches

### DIFF
--- a/buildscripts/makefile
+++ b/buildscripts/makefile
@@ -79,7 +79,7 @@ textures:
 	for file in $$(find ../* -name "textures.txt" -not -path "../textures.txt") ; do \
 		while IFS='/' read -r line ; do \
 			d=$$(dirname $$file) ; \
-			d="$${d:2}/patches" ; \
+			d="$${d:3}/patches" ; \
 			echo "$${line/patches/$$d}" >> ../textures.txt ; \
 		done < $$file ; \
 	done

--- a/textures.txt
+++ b/textures.txt
@@ -3,12 +3,12 @@
 Sprite "HSCVP0", 9, 11
 {
 	Offset 4, 11
-	Patch "/2fcartridges/patches/UaS_2FCartridge.png", 0, 0
+	Patch "2fcartridges/patches/UaS_2FCartridge.png", 0, 0
 }
 Sprite "UGSPA0", 22, 27
 {
 	Offset 11, 27
-	Patch "/ammopouch/patches/UaS_AmmoPouch.png", 0, 0
+	Patch "ammopouch/patches/UaS_AmmoPouch.png", 0, 0
 }
 
 Sprite "UGSPB0", 27, 22
@@ -16,7 +16,7 @@ Sprite "UGSPB0", 27, 22
 	Offset 12, 22
 	xscale 0.87
 	yscale 1.2
-	Patch "/ammopouch/patches/UaS_AmmoPouch.png", 0, 0
+	Patch "ammopouch/patches/UaS_AmmoPouch.png", 0, 0
 	{
 		Rotate -90
 	}
@@ -25,7 +25,7 @@ Sprite "UGSPB0", 27, 22
 Sprite "UGSPC0", 22, 27
 {
 	Offset 11, 27
-	Patch "/ammopouch/patches/UaS_AmmoPouch.png", 0, 0
+	Patch "ammopouch/patches/UaS_AmmoPouch.png", 0, 0
 	Patch "STASQGR", 15, 12
 }
 Sprite "HSCVA0", 23, 12
@@ -33,7 +33,7 @@ Sprite "HSCVA0", 23, 12
 	XScale 2.000
 	YScale 2.000
 	Offset 11, 11
-	Patch "/hunger/patches/UaS_Ration.png", 0, 0
+	Patch "hunger/patches/UaS_Ration.png", 0, 0
 }
 
 Sprite "HSCVC0", 23, 11
@@ -41,13 +41,13 @@ Sprite "HSCVC0", 23, 11
 	XScale 3.000
 	YScale 3.000
 	Offset 11, 10
-	Patch "/hunger/patches/UaS_RationDebris.png", 0, 0
+	Patch "hunger/patches/UaS_RationDebris.png", 0, 0
 }
 
 Sprite "HSCVB0", 28, 16
 {
 	Offset 14, 15
-	Patch "/hunger/patches/UaS_Messkit.png", 0, 0
+	Patch "hunger/patches/UaS_Messkit.png", 0, 0
 }
 
 Sprite "HSCVR0", 23, 12
@@ -55,21 +55,21 @@ Sprite "HSCVR0", 23, 12
 	XScale 2.000
 	YScale 2.000
 	Offset 11, 11
-	Patch "/hunger/patches/UaS_WaterRation.png", 0, 0
+	Patch "hunger/patches/UaS_WaterRation.png", 0, 0
 }
 Sprite "UGSIE0", 25, 14
 {
 	XScale 1.500
 	YScale 1.500
 	Offset 12, 14
-	Patch "/laserlight/patches/UaS_LaserLight.png", 0, 0
+	Patch "laserlight/patches/UaS_LaserLight.png", 0, 0
 }
 Sprite "UGSIB0", 72, 16
 {
 	XScale 8.000
 	YScale 8.000
 	Offset 36, 8
-	Patch "/markers/patches/UaS_Glowstick.png", 0, 0
+	Patch "markers/patches/UaS_Glowstick.png", 0, 0
 }
 
 Sprite "UGSIC0", 72, 16
@@ -77,7 +77,7 @@ Sprite "UGSIC0", 72, 16
 	XScale 8.000
 	YScale 8.000
 	Offset 36, 8
-	Patch "/markers/patches/UaS_GlowstickLit.png", 0, 0
+	Patch "markers/patches/UaS_GlowstickLit.png", 0, 0
 }
 
 Sprite "UGSIH0", 5, 10
@@ -98,19 +98,19 @@ Sprite "UGSIF0", 17, 18
 	XScale 1.500
 	YScale 1.500
 	Offset 7, 18
-	Patch "/medical/patches/UaS_TraumaKit.png", 0, 0
+	Patch "medical/patches/UaS_TraumaKit.png", 0, 0
 }
 Sprite "UGSID0", 48, 48
 {
 	XScale 2.500
 	YScale 3.000
 	Offset 24, 46
-	Patch "/respirator/patches/UaS_Respirator.png", 0, 0
+	Patch "respirator/patches/UaS_Respirator.png", 0, 0
 }
 Sprite "HSCVE0", 15, 20
 {
 	Offset 8, 19
-	Patch "/scarcity/patches/UaS_StimDebris.png", 0, 0
+	Patch "scarcity/patches/UaS_StimDebris.png", 0, 0
 	{
 		Translation "176:191=124:127"
 	}
@@ -119,7 +119,7 @@ Sprite "HSCVE0", 15, 20
 Sprite "HSCVF0", 28, 23
 {
 	Offset 12, 22
-	Patch "/scarcity/patches/UaS_MedikitDebris.png", 0, 0
+	Patch "scarcity/patches/UaS_MedikitDebris.png", 0, 0
 	{
 		Translation "176:191=124:127", "32:47=124:127"
 	}
@@ -128,46 +128,46 @@ Sprite "HSCVF0", 28, 23
 Sprite "HSCVG0", 28, 23
 {
 	Offset 12, 22
-	Patch "/scarcity/patches/UaS_ZerkDebris.png", 0, 0
+	Patch "scarcity/patches/UaS_ZerkDebris.png", 0, 0
 }
 
 Sprite "HSCVJ0", 28, 26
 {
 	Offset 13, 24
-	Patch "/scarcity/patches/UaS_MapDamaged1.png", 0, 0
+	Patch "scarcity/patches/UaS_MapDamaged1.png", 0, 0
 }
 
 Sprite "HSCVK0", 28, 26
 {
 	Offset 13, 24
-	Patch "/scarcity/patches/UaS_MapDamaged2.png", 0, 0
+	Patch "scarcity/patches/UaS_MapDamaged2.png", 0, 0
 }
 
 Sprite "HSCVL0", 28, 26
 {
 	Offset 13, 24
-	Patch "/scarcity/patches/UaS_MapDamaged3.png", 0, 0
+	Patch "scarcity/patches/UaS_MapDamaged3.png", 0, 0
 }
 
 Sprite "HSCVM0", 28, 26
 {
 	Offset 13, 24
-	Patch "/scarcity/patches/UaS_MapDamaged4.png", 0, 0
+	Patch "scarcity/patches/UaS_MapDamaged4.png", 0, 0
 }
 
 Sprite "HSCVN0", 28, 26
 {
 	Offset 13, 24
-	Patch "/scarcity/patches/UaS_MapDamaged5.png", 0, 0
+	Patch "scarcity/patches/UaS_MapDamaged5.png", 0, 0
 }
 
 Sprite "HSCVO0", 28, 12
 {
 	Offset 13, 9
-	Patch "/scarcity/patches/UaS_NVGBroken.png", 0, 0
+	Patch "scarcity/patches/UaS_NVGBroken.png", 0, 0
 }
 Sprite "HSCVI0", 28, 33
 {
 	Offset 15, 16
-	Patch "/stabilizer/patches/UaS_Sling.png", 0, 0
+	Patch "stabilizer/patches/UaS_Sling.png", 0, 0
 }


### PR DESCRIPTION
Fixes LZDoom failing to load composite textures.