### PR TITLE
Remove unused vignette shader

### DIFF
--- a/core/module/core.zsc
+++ b/core/module/core.zsc
@@ -1,12 +1,2 @@
 // Static functions for general use
-class UaS : EventHandler{
-	static play void EnableVignette(PlayerInfo p, double i = 120, double f = 0.08) {
-		Shader.SetUniform1f(p, "vignetteshader", "intensity", i);
-		Shader.SetUniform1f(p, "vignetteshader", "falloff", f);
-		Shader.SetEnabled(p, "vignetteshader", true);
-	}
-
-	static play void DisableVignette(PlayerInfo p) {
-		Shader.SetEnabled(p, "vignetteshader", false);
-	}
-}
+class UaS : EventHandler{}

--- a/gldefs.txt
+++ b/gldefs.txt
@@ -1,10 +1,3 @@
-HardwareShader PostProcess scene {
-	Name "vignetteshader"
-	Shader "shaders/uas_vignette.fp" 330
-	Uniform float intensity
-	Uniform float falloff
-}
-
 HardwareShader PostProcess scene
 {
 	Name "stealthvision"


### PR DESCRIPTION
Removes all remaining references to the vignette shader (they were causing LZDoom to abort on level load).