### PR TITLE
Ammopouch: Don't block hd_strip

### DIFF
--- a/ammopouch/module/ammopouch.zsc
+++ b/ammopouch/module/ammopouch.zsc
@@ -10,6 +10,7 @@ class UaS_AmmoPouch : HDBackpack {
 		Inventory.Icon "UGSPA0";
 		Inventory.PickupMessage "Picked up an ammo pouch!";
 		scale 0.6;
+		hdweapon.wornlayer 0;
 		hdweapon.refid UAS_HDLD_AMMOPOUCH;
 	}
 


### PR DESCRIPTION
Fixes not being able to take off armor with an ammo pouch in your inventory.