### PR TITLE
Traumakit: Generalize strip check

### DIFF
--- a/medical/module/traumakit/traumakit.zsc
+++ b/medical/module/traumakit/traumakit.zsc
@@ -93,10 +93,13 @@ class UaS_TraumaKit : HDWeapon {
 	bool HandleStrip() {
 		if (!autostrip) { autostrip = CVar.GetCVar("hd_autostrip", owner.player); }
 		string itemname, imperative;
-		// check for worn items, otherwise exit early
+		// check for intervening items, otherwise exit early
+		bool intervening = !HDPlayerPawn.CheckStrip(patient, patient, false);
+		if(!intervening) return true;
+
 		if(patient.countinv("WornRadsuit")) { itemname = "environment suit "; }
 		else if(patient.countinv("HDArmourWorn")) { itemname = "armour "; }
-		else { return true; }
+		else { itemname = "worn layers "; }
 
 		// check owner or other
 		if(patient == owner) {


### PR DESCRIPTION
Generalizes the trauma kit strip check a little. Custom worn items will block wound access with a general "remove worn layers" message.