### PR TITLE
Tweak incapacitated enemy AI

### DIFF
--- a/ai/cvarinfo.txt
+++ b/ai/cvarinfo.txt
@@ -4,3 +4,4 @@ server bool UaS_AI_Wounding = true;
 server bool UaS_AI_Flashlights = true;
 server noarchive bool UaS_AI_Stealth = false;
 server noarchive bool UaS_AI_Debug_Override = false;
+server float UaS_AI_PlayDead = 0.5;

--- a/ai/menudef.txt
+++ b/ai/menudef.txt
@@ -13,4 +13,5 @@ OptionMenu "UaS_AI_Options" {
 	Option "Wounding","UaS_AI_Wounding","OnOff"
 	Option "Lights","UaS_AI_Flashlights","OnOff"
 	Option "Stealth","UaS_AI_Stealth","OnOff", "UaS_AI_Debug_Override"
+	Slider "'Play Dead' chance","UaS_AI_PlayDead", 0, 1, 0.05, 2
 }

--- a/ai/module/ai_flashlight.zsc
+++ b/ai/module/ai_flashlight.zsc
@@ -20,7 +20,11 @@ extend class UaS_AI_Handler {
 		if (!BotClass && !HumanClass) { return; }
 
 		string flc = "UaS_LaserLightModule";
-		if (!owner.FindInventory(flc)) { owner.giveinventory(flc, 1); }
+		UaS_LaserLightModule LLM = UaS_LaserLightModule(owner.FindInventory(flc));
+		if (!LLM) {
+			owner.giveinventory(flc, 1);
+			LLM = UaS_LaserLightModule(owner.FindInventory(flc));
+		}
 
 		bool isowneraiming = (
 			owner.frame ==  4 || owner.frame ==  5 ||
@@ -39,9 +43,15 @@ extend class UaS_AI_Handler {
 			owner.LineTrace(owner.angle, 256, owner.pitch, TRF_THRUACTORS, owner.height * 0.75, data: lookSpot);
 			int lightlevel = int(lookSpot.HitSector.LightLevel + owner.cursector.lightlevel) / 2;
 
-			// More likely to activate in darker areas
-			if (random[aillm](0,192) > lightlevel) { UaS.SendIntent("LLM_Toggle", "On", owner); }
-			else { UaS.SendIntent("LLM_Toggle", "Off", owner); }
+			if (owner.InStateSequence(owner.CurState, owner.ResolveState("falldown"))) { // don't run the normal check logic if we're incapacitated
+				if (LLM.activated && UaS.RandomChance(UaS_AI_PlayDead)) {
+					UaS.SendIntent("LLM_Toggle", "Off", owner);
+				}
+			} else {
+				// More likely to activate in darker areas
+				if (random[aillm](0,192) > lightlevel) { UaS.SendIntent("LLM_Toggle", "On", owner); }
+				else { UaS.SendIntent("LLM_Toggle", "Off", owner); }
+			}
 
 			// misc other adjustments
 			recheck = max(random[aillm](35, 175), lightlevel); // recheck more often in darker areas

--- a/ai/module/ai_flashlight.zsc
+++ b/ai/module/ai_flashlight.zsc
@@ -20,11 +20,7 @@ extend class UaS_AI_Handler {
 		if (!BotClass && !HumanClass) { return; }
 
 		string flc = "UaS_LaserLightModule";
-		UaS_LaserLightModule LLM = UaS_LaserLightModule(owner.FindInventory(flc));
-		if (!LLM) {
-			owner.giveinventory(flc, 1);
-			LLM = UaS_LaserLightModule(owner.FindInventory(flc));
-		}
+		if (!owner.FindInventory(flc)) { owner.giveinventory(flc, 1); }
 
 		bool isowneraiming = (
 			owner.frame ==  4 || owner.frame ==  5 ||
@@ -44,7 +40,7 @@ extend class UaS_AI_Handler {
 			int lightlevel = int(lookSpot.HitSector.LightLevel + owner.cursector.lightlevel) / 2;
 
 			if (owner.InStateSequence(owner.CurState, owner.ResolveState("falldown"))) { // don't run the normal check logic if we're incapacitated
-				if (LLM.activated && UaS.RandomChance(UaS_AI_PlayDead)) {
+				if (UaS.RandomChance(UaS_AI_PlayDead)) {
 					UaS.SendIntent("LLM_Toggle", "Off", owner);
 				}
 			} else {

--- a/ai/module/ai_wounded.zsc
+++ b/ai/module/ai_wounded.zsc
@@ -15,15 +15,18 @@ extend class UaS_AI_Handler {
 		if(!owner || owner.health <= 0 ) { return; }
 		if(owner.health < baseHealth) {
 			// Calculate health factor
-			healthFactor = owner.health / double(baseHealth);
+			bool incapacitated = owner.InStateSequence(owner.CurState, owner.ResolveState("falldown"));
+			healthFactor = incapacitated ? 0.1 : owner.health / double(baseHealth);
 			healthFactor = clamp(healthFactor, 0.1, 1.0);
 
 			// Reduce speed
 			owner.speed = baseSpeed * healthFactor;
 
 			// Jitter angle / pitch
-			owner.A_SetAngle(owner.angle + (random[ai](-15, 15) * (1.0 - healthFactor)), SPF_INTERPOLATE);
-			owner.A_SetPitch(owner.pitch + (random[ai](-10, 10) * (1.0 - healthFactor)), SPF_INTERPOLATE|SPF_FORCECLAMP);
+			if(!incapacitated) { // Don't jitter while incapacitated
+				owner.A_SetAngle(owner.angle + (random[ai](-15, 15) * (1.0 - healthFactor)), SPF_INTERPOLATE);
+				owner.A_SetPitch(owner.pitch + (random[ai](-10, 10) * (1.0 - healthFactor)), SPF_INTERPOLATE|SPF_FORCECLAMP);
+			}
 
 			// Occasionally cry out in pain and select a random fear state
 			// (more likely to be frightened the lower heathFactor is)

--- a/cvarinfo.txt
+++ b/cvarinfo.txt
@@ -2,6 +2,7 @@
 server bool UaS_AdvancedAIEnabled = false;
 server bool UaS_AI_Flashlights = true;
 server bool UaS_AI_Wounding = true;
+server float UaS_AI_PlayDead = 0.5;
 server noarchive bool UaS_AI_Debug_Override = false;
 server noarchive bool UaS_AI_Searching = false;
 server noarchive bool UaS_AI_Stealth = false;

--- a/laserlight/module/laser.zsc
+++ b/laserlight/module/laser.zsc
@@ -195,6 +195,11 @@ class UaS_LaserLightModule : HDWeapon {
 					//if (!isowneraiming) { llm.pitchoffset += 20; }
 				}
 			}
+			// no random light movement while incapacitated
+			if (owner.InStateSequence(owner.CurState, owner.ResolveState("falldown"))) {
+				angleoffset = 0;
+				pitchoffset = 0;
+			}
 			// if (isowneraiming && mode == 3) {
 				// angleoffset = 0;
 				// pitchoffset = 0;

--- a/menudef.txt
+++ b/menudef.txt
@@ -53,6 +53,7 @@ OptionMenu "UaS_AI_Options" {
 	Option "Wounding","UaS_AI_Wounding","OnOff"
 	Option "Lights","UaS_AI_Flashlights","OnOff"
 	Option "Stealth","UaS_AI_Stealth","OnOff", "UaS_AI_Debug_Override"
+	Slider "'Play Dead' chance","UaS_AI_PlayDead", 0, 1, 0.05, 2
 }
 AddOptionMenu "UaS_LoadedModules" {
 	StaticText "Aim Tweaks"


### PR DESCRIPTION
- Incapacitated enemies can now 'play dead,' which means they will turn their flashlight or laser off.
    - This was actually surprisingly effective in playtesting, since I got really used to checking for lights instead of actually checking to see if monsters were really dead or not.
    - The chance for an enemy to play dead every light recheck is configurable.
- Incapacitated enemies will no longer have aim jitter.
- Incapacitated enemies will no longer jitter their flashlight/laser module around. (Formerly, this would stack with the normal damage jitter from wounding, causing it to aim all over the place.)
- An enemy being incapacitated has a HealthFactor of 0.1 for the duration of the incapacitation.