### PR TITLE
[NEEDS BALANCING] Make traumakit painkillers contribute to stim OD

### DIFF
--- a/medical/module/traumakit/traumakit_painkiller.zsc
+++ b/medical/module/traumakit/traumakit_painkiller.zsc
@@ -22,6 +22,7 @@ extend class UaS_TraumaKit {
 				random[uas_tk](25,75) +
 				random[uas_tk](25,75)) / 3;
 			currentWound.painkiller = min(currentWound.painkiller + inject, 100);
+			patient.stimcount += HDStim.HDSTIM_DOSE/20;
 			currentmessage.text = "Anesthetic injected.";
 			currentmessage.timeout = 2*35;
 			patient.A_MuzzleClimb(

--- a/medical/module/traumakit/traumakit_painkiller.zsc
+++ b/medical/module/traumakit/traumakit_painkiller.zsc
@@ -22,7 +22,7 @@ extend class UaS_TraumaKit {
 				random[uas_tk](25,75) +
 				random[uas_tk](25,75)) / 3;
 			currentWound.painkiller = min(currentWound.painkiller + inject, 100);
-			patient.stimcount += HDStim.HDSTIM_DOSE/20;
+			patient.stimcount += (HDStim.HDSTIM_MAX - HDStim.HDSTIM_DOSE)/20;
 			currentmessage.text = "Anesthetic injected.";
 			currentmessage.timeout = 2*35;
 			patient.A_MuzzleClimb(


### PR DESCRIPTION
Each use of anaesthetic counts as ¹/₂₀ᵗʰ of a stim use, as outlined in #117.
HOWEVER: This means that using one stim and 4 anaesthetics will put you at the OD threshold, because a stim is 400 stimcount and the overdose is at 480 stimcount. I think this should probably be tweaked somewhat, or there should be a way to tell if you're too close to the OD limit to safely use anaesthetics. When I play, I try to ration my painkillers and only use them on things that need a lot of biofoam or obstructions (and only use two full doses for something with both), but I think this might become a noob trap.
One potential idea is to make stims themselves act as a low-level anaesthetic for all wounds, so that anaesthetic is less necessary if you've already used one, but that might just make it so that the meta is using only stims instead. If there are any other ideas on how to balance this, I'd like to hear them.