### PR TITLE
Fix stimcount painkiller factor rounding to zero

### DIFF
--- a/medical/module/medical_handler.zsc
+++ b/medical/module/medical_handler.zsc
@@ -47,7 +47,7 @@ class UaS_WoundHandler : Inventory {
 				continue;
 			}
 			critwounds[i].TickWound();
-			critwounds[i].painkiller = max(critwounds[i].painkiller, plr.stimcount * (50/HDStim.HDSTIM_DOSE));
+			critwounds[i].painkiller = max(critwounds[i].painkiller, plr.countinv("HDStim") * (50./float(HDStim.HDSTIM_DOSE)));
 		}
 
 		// tabulate new wound array total points


### PR DESCRIPTION
Had to use countinv instead of the actual stimcount variable. Also, it was rounding down to zero because integer division.