### PR TITLE
add respirator token

### DIFF
--- a/respirator/module/resp_controls.zsc
+++ b/respirator/module/resp_controls.zsc
@@ -16,7 +16,8 @@ extend class UaS_Respirator {
 		return false;
 	}
 
-	void ToggleRespirator() {
+	void ToggleRespirator()
+	{
 		owner.A_StopSound(CHAN_BREATH);
 		owner.A_StartSound("UaS/respirator/click",
 			CHAN_AUTO, 0, 1, ATTN_STATIC);

--- a/respirator/module/resp_functions.zsc
+++ b/respirator/module/resp_functions.zsc
@@ -1,4 +1,30 @@
-extend class UaS_Respirator {
+extend class UaS_Respirator
+{
+
+
+	override void tick()
+	{
+		super.tick();
+		if(isfrozen())return;
+		
+		// Check for whether or not this specific respirator is active.
+		// checks for owner since otherwise we'd be indexing 0. 
+		if(owner)
+		{
+			// This check activates when the player first toggles the rsp.
+			if(activated && !owner.findinventory("uas_respirator_worn"))
+			{
+				owner.A_GiveInventory("uas_respirator_worn", 1);
+			}
+			// This toggles whenever they turn the rsp off. 
+			else if (!activated)
+			{
+				owner.A_TakeInventory("uas_respirator_worn", 1);
+			}
+		}
+	}
+
+
 	override void DoEffect() {
 		//console.printf("breath "..owner.player.air_finished - Level.maptime);
 		//console.printf(""..airunits);
@@ -68,7 +94,12 @@ extend class UaS_Respirator {
 	}
 
 	override void DetachFromOwner() {
-		if (activated) { ToggleRespirator(); }
+		if (activated)
+		{
+			ToggleRespirator();
+			// Removes the worn token if active. 
+			owner.A_TakeInventory("uas_respirator_worn", 1);
+		}
 		super.DetachFromOwner();
 	}
 
@@ -76,5 +107,15 @@ extend class UaS_Respirator {
 		spawn:
 			UGSI D 0 -1;
 			stop;
+	}
+}
+
+
+// an inventory token for players. 
+class uas_respirator_worn : inventory
+{
+	default
+	{
+		inventory.maxamount 1;
 	}
 }


### PR DESCRIPTION
Adds an easily-check-able inventory token for whenever a respirator is active (worn) on a player's person, which parodies the status of respirator.activated. I am proposing this change for cross-mod compatibility, since without adding UAS as a dependency there's no easy way to check for this otherwise. If you are worried about the performance impact of this check on active players, staggering the check with (level.time % sometickamount) should alleviate that somewhat. 