### PR TITLE
menudef: Move settings to HDAddonMenu

### DIFF
--- a/core/menudef.txt
+++ b/core/menudef.txt
@@ -2,7 +2,7 @@ AddOptionMenu "OptionsMenu" {
 	Submenu "Ugly as Sin Settings", "UaS_Options"
 }
 
-AddOptionMenu "HDOptionsMenu" after "HDControlsMenu" {
+AddOptionMenu "HDAddonMenu" {
 	Submenu "Ugly as Sin Settings", "UaS_Options"
 }
 

--- a/menudef.txt
+++ b/menudef.txt
@@ -4,7 +4,7 @@ AddOptionMenu "OptionsMenu" {
 	Submenu "Ugly as Sin Settings", "UaS_Options"
 }
 
-AddOptionMenu "HDOptionsMenu" after "HDControlsMenu" {
+AddOptionMenu "HDAddonMenu" {
 	Submenu "Ugly as Sin Settings", "UaS_Options"
 }
 


### PR DESCRIPTION
Moves the settings option from `HDOptionsMenu` to `HDAddonMenu`, which was introduced recently.