### PR TITLE
Prevent Scarcity from running on The Range

### DIFF
--- a/scarcity/module/scarcity.zsc
+++ b/scarcity/module/scarcity.zsc
@@ -7,6 +7,7 @@ class UaS_Scarcity_Handler : EventHandler {
 	}
 
 	override void WorldTick() {
+		if(level.MapName ~== "RANGE") { return; }
 		if(level.maptime != 1) { return; }
 		if(UaS_ScarcityEnabled == false) { return; }
 


### PR DESCRIPTION
This is mostly for the modified NewRange, but also so the vanilla Range stays clean.