### PR TITLE
deathfade: Allow players to enable/disable when already dead

### DIFF
--- a/deathfade/module/deathfade.zsc
+++ b/deathfade/module/deathfade.zsc
@@ -2,7 +2,11 @@ class UaS_DeathFade_Bootstrap : EventHandler {
 	override void WorldTick() {
 		for (int i = 0; i < MAXPLAYERS; i++) {
 			if (!playeringame[i]) { continue; }
-			if(players[i].health > 0) { Deathfade_Bootstrap(i, false); }
+			bool doFade = DoDeathFade(i);
+			if (players[i].health > 0 || !doFade) { Deathfade_Bootstrap(i, false); }
+			else if (players[i].health <= 0 && doFade) {
+				Shader.SetEnabled(players[i], "deathfade", true);
+			}
 		}
 	}
 


### PR DESCRIPTION
Very handy when someone accidentally left this option on while playing coop (they can't see anything)