### PR TITLE
deathfade: Fix VM aborts caused by a dead player leaving with deathfade on

### DIFF
--- a/deathfade/module/deathfade.zsc
+++ b/deathfade/module/deathfade.zsc
@@ -43,8 +43,10 @@ class UaS_DeathFader : Thinker {
 
 	override void Tick() {
 		super.Tick();
-		fadeamount = min(fadeamount + (1.0/counttoblack), 1.0);
-		Shader.SetUniform1f(plr.player, "deathfade", "fadeamount", fadeamount);
-		if (fadeamount >= 1.0 || plr.health > 0) { destroy(); }
+		if (plr && fadeamount < 1.0 && plr.health <= 0) {
+			fadeamount = min(fadeamount + (1.0/counttoblack), 1.0);
+			Shader.SetUniform1f(plr.player, "deathfade", "fadeamount", fadeamount);
+		}
+		else { Destroy(); }
 	}
 }


### PR DESCRIPTION
In multiplayer, if a player dies with deathfade enabled, and leaves the game, everyone else will suffer a VM abort.
This just adds a simple check to see if the player still exists.