### PR TITLE
Localize Looting Help Text

### DIFF
--- a/LANGUAGE
+++ b/LANGUAGE
@@ -58,6 +58,11 @@ RESPIRATOR_EMPTY                                      = "It is empty.";
 RESPIRATOR_AMT_PREFIX                                 = "It is at ";
 RESPIRATOR_AMT_SUFFIX                                 = " percent capacity";
 
+
+// Looting Module
+FISTWH_USE                                            = "   Crouch next to a body\n      and hold to search.";
+
+
 //-----------------
 // Food Module Language Lumps
 //-----------------

--- a/looting/LANGUAGE
+++ b/looting/LANGUAGE
@@ -1,0 +1,1 @@
+FISTWH_USE = "   Crouch next to a body\n      and hold to search.";

--- a/looting/module/looting.zsc
+++ b/looting/module/looting.zsc
@@ -32,7 +32,7 @@ class UaS_Looting_Handler : Inventory {
 		}
 
 		HDPlayerPawn(owner).wephelptext = HDWeapon(owner.player.ReadyWeapon).gethelptext()..
-			WEPHELP_USE.."   Crouch next to a body\n      and hold to search.";
+			WEPHELP_BTCOL..StringTable.Localize("$WPHUSE")..WEPHELP_RGCOL..Stringtable.Localize("$FISTWH_USE");
 
 		// Nudge owner angle/pitch
 		owner.angle += anglevel;


### PR DESCRIPTION
Was hoping to use the `LWPHELP_USE` constant, but that's defined in `HDWeapon`, not `Inventory`, so instead the value that the constant uses was copied.