### PR TITLE
medical: Clamp visual wound alpha

### DIFF
--- a/medical/module/medical_wound.zsc
+++ b/medical/module/medical_wound.zsc
@@ -261,7 +261,7 @@ extend class UaS_Wound {
 		BP.Flags = SPF_REPLACE;
 		BP.FadeStep = 0;
 		BP.Style = STYLE_Normal;
-		BP.StartAlpha = max((depth/width), 0.3);
+		BP.StartAlpha = min(1, max((depth/width), 0.3));
 		level.SpawnParticle(BP);
 
 		// Do appearing and drops running down body


### PR DESCRIPTION
Prevents some funky visual effects from happening (not the good kind)

Also this is done with the assumption that the minimum alpha value is `0.3` since the calculation is `max((depth/width), 0.3)`