### PR TITLE
medical: Allow the Trauma Kit to rip bandages

### DIFF
--- a/LANGUAGE
+++ b/LANGUAGE
@@ -272,6 +272,7 @@ UI_TRK_BANDAGE = "bandage";
 UI_TRK_WORNLAYERS = "worn layers";
 UI_TRK_TAKEOFF_YOU = "Take off your %s first!\n";
 UI_TRK_TAKEOFF_THEY = "Have them take off their %s first!\n";
+UI_TRK_BANDAGETIP = "(hold Fire to remove bandage)";
 
 // Help Text: Trauma Kit
 HELPTEXT_TRK_NORMAL =

--- a/medical/language
+++ b/medical/language
@@ -204,6 +204,7 @@ UI_TRK_BANDAGE = "bandage";
 UI_TRK_WORNLAYERS = "worn layers";
 UI_TRK_TAKEOFF_YOU = "Take off your %s first!\n";
 UI_TRK_TAKEOFF_THEY = "Have them take off their %s first!\n";
+UI_TRK_BANDAGETIP = "(hold Fire to remove bandage)";
 
 // Help Text: Trauma Kit
 HELPTEXT_TRK_NORMAL =

--- a/medical/module/selfbandage/selfbandage.zsc
+++ b/medical/module/selfbandage/selfbandage.zsc
@@ -47,16 +47,15 @@ class UaS_SelfBandage : UaS_MedicalTool {
 	}
 
 	override void DoEffect() {
-		if (!(owner.player.ReadyWeapon is "UaS_SelfBandage")) { return; }
-
-		Super.DoEffect();
-
 		if (timer >= 0) { --timer; }
 		if (timeout >= 0) { --timeout; }
 		if (timeout <= 0) { ResetAction(); }
 		if (currentMessage.timeout > 0) { --currentMessage.timeout; }
 		else { currentMessage.text = ""; }
 
+		if (!(owner.player.ReadyWeapon is "UaS_SelfBandage")) { return; }
+
+		Super.DoEffect();
 		CycleWounds();
 		TryRipBloodbag();
 		TryStripWorn();

--- a/medical/module/traumakit/traumakit.zsc
+++ b/medical/module/traumakit/traumakit.zsc
@@ -85,6 +85,7 @@ class UaS_TraumaKit : UaS_MedicalTool {
 				break;
 		}
 
+		HandleBandages();
 		TickMessages();
 	}
 
@@ -152,25 +153,36 @@ class UaS_TraumaKit : UaS_MedicalTool {
 	bool HandleStrip() {
 		string itemname, imperative;
 		// check for intervening items, otherwise exit early
+		bool isBandaged = (mti.currentWound && mti.currentWound.patched > 0.);
 		let blockinv = HDWoundFixer.CheckCovered(mti.patient, CHECKCOV_CHECKBODY);
-		bool intervening = (
-			blockinv
-			|| !HDPlayerPawn.CheckStrip(mti.patient, mti.patient, false)
-			|| (mti.currentWound && mti.currentWound.patched > 0.)
-		);
-		if (!intervening) { return true; }
-
 		if (blockinv) { itemname = blockinv.GetTag(); }
-		else if (mti.currentWound && mti.currentWound.patched > 0.) { itemname = Stringtable.Localize("$UI_TRK_BANDAGE"); }
-		else { itemname = Stringtable.Localize("$UI_TRK_WORNLAYERS"); }
+		else if (!HDPlayerPawn.CheckStrip(mti.patient, mti.patient, false)) { itemname = Stringtable.Localize("$UI_TRK_WORNLAYERS"); }
+		else if (isBandaged) { itemname = Stringtable.Localize("$UI_TRK_BANDAGE"); }
+		else { return true; }
 
 		// check owner or other
 		imperative = Stringtable.Localize("$UI_TRK_TAKEOFF_"..((mti.patient == owner)? "YOU" : "THEY"));
 
 		// display message
 		currentmessage.text = String.Format(imperative, itemname);
+		if (isBandaged) { currentmessage.text = currentmessage.text..Stringtable.Localize("$UI_TRK_BANDAGETIP"); }
 		currentmessage.timeout = 2*35;
 		return false;
+	}
+
+	void HandleBandages() {
+		if (!(
+			mti.currentWound
+			&& mti.currentWound.patched > 0.
+			&& owner.player.cmd.buttons & BT_ATTACK
+		)) { return; }
+
+		let bandage = UaS_SelfBandage(owner.FindInventory("UaS_SelfBandage"));
+		bandage.TryRipBandage();
+		if (bandage.currentmessage.text != "") {
+			currentmessage.text = bandage.currentmessage.text;
+			currentmessage.timeout = bandage.currentmessage.timeout;
+		}
 	}
 
 	void DebugStatus() {

--- a/medical/readme.md
+++ b/medical/readme.md
@@ -23,5 +23,7 @@ The alternative medikit. In order to let your wounds heal up, you need to operat
 Use the correct tools to treat whatever is stopping your wounds from healing up. (note: try to get all of the listed statuses close to green)
 The wound will only start to heal up once it becomes green in the wounds list.
 
+Note: If the wound you're operating on is bandaged, you can hold Fire to rip it off. (or AltFire in the bandage tool)
+
 ## Credits
  - bunyear/Tapwave: Made the trauma kit tool sprites


### PR DESCRIPTION
(suggested by Sledge)
Allows the Trauma Kit to rip bandages by holding down Fire.
Should hopefully make the Trauma Kit less clunky (i.e: no more switching back and forth just to rip bandages)

Note: I also simplified the checks in `HandleStrip()` a bit. If you prefer how it was before, let me know and I'll revert it back.
