### PR TITLE
Medical: Use player blood colour for wounds/blood droplets

### DIFF
--- a/medical/module/medical_wound.zsc
+++ b/medical/module/medical_wound.zsc
@@ -249,20 +249,22 @@ extend class UaS_Wound {
 		double avgsize = (width + depth) / 2.0;
 
 		// Spawn a wound particle;
-		if (depth >= 8) { BP.Texture = TexMan.CheckForTexture ("BLUDC0"); }
-		else if (depth >= 4) { BP.Texture = TexMan.CheckForTexture ("BLUDB0"); }
-		else if (depth >= 1) { BP.Texture = TexMan.CheckForTexture ("BLUDA0"); }
+		if (depth >= 8) { BP.Texture = TexMan.CheckForTexture ("UASBLUDC0"); }
+		else if (depth >= 4) { BP.Texture = TexMan.CheckForTexture ("UASBLUDB0"); }
+		else if (depth >= 1) { BP.Texture = TexMan.CheckForTexture ("UASBLUDA0"); }
 		else { BP.Texture = TexMan.CheckForTexture (""); }
-		BP.Color1 = "DarkRed";
+		if (bleeder.BloodColor) { BP.Color1 = bleeder.BloodColor; }
+		else { BP.Color1 = "DarkRed"; }
 		BP.Pos = oldpos;
 		BP.Lifetime = 1;
 		BP.Vel = interpvel;
 		BP.Size = (depth+1)/2;
 		BP.Flags = SPF_REPLACE;
 		BP.FadeStep = 0;
-		BP.Style = STYLE_Normal;
+		BP.Style = STYLE_Shaded;
 		if (width > 0.) { BP.StartAlpha = min(1, max((depth / width), 0.3)); }
 		else { BP.StartAlpha = 0.3; }
+		if (depth >= 1) { BP.StartAlpha *= 2.0; } // STYLE_Shaded applies a lot of transparency for some reason
 		level.SpawnParticle(BP);
 
 		// Do appearing and drops running down body
@@ -278,6 +280,7 @@ extend class UaS_Wound {
 			BP.Accel.Z = 0;
 			BP.Vel = interpvel;
 			BP.Vel.Z += d.vel.z;
+			BP.Style = STYLE_Normal;
 
 			if (d.size >= d.maxsize) {
 				d.vel.z = clamp(

--- a/medical/module/selfbandage/selfbandage_hud.zsc
+++ b/medical/module/selfbandage/selfbandage_hud.zsc
@@ -38,7 +38,10 @@ extend class UaS_SelfBandage {
 
 		// bleeding?
 		if (wound.depth > 0.) {
-			let blud = TexMan.CheckForTexture("BLUDC0");
+			TextureID blud;
+			if (wound.depth >= 8) { blud = TexMan.CheckForTexture("BLUDC0"); }
+			else if (wound.depth >= 4) { blud = TexMan.CheckForTexture("BLUDB0"); }
+			else { blud = TexMan.CheckForTexture("BLUDA0"); }
 			Vector2 bludScale = woundScale * log(wound.depth + 1) / 2;
 			Vector2 bludOffset = (
 				sb.pSmallFont.mFont.GetCharWidth("X") / 2 * woundScale.x,
@@ -50,7 +53,8 @@ extend class UaS_SelfBandage {
 				woundPosition + bludOffset,
 				sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER,
 				woundAlpha - 0.25,
-				scale: bludScale
+				scale: bludScale,
+				translation: wound.bleeder.BloodTranslation
 			);
 		}
 

--- a/medical/textures.txt
+++ b/medical/textures.txt
@@ -45,3 +45,33 @@ Graphic "CIRCLEBG", 400, 400
 {
 	Patch "patches/circlebg.png", 0, 0
 }
+
+Graphic "UASBLUDC0", 12, 11
+{
+	Offset 7, 6
+	Patch "BLUDC0", 0, 0
+	{
+		Translation Desaturate, 31
+		Style Translucent
+	}
+}
+
+Graphic "UASBLUDB0", 8, 8
+{
+	Offset 4, 4
+	Patch "BLUDB0", 0, 0
+	{
+		Translation Desaturate, 31
+		Style Translucent
+	}
+}
+
+Graphic "UASBLUDA0", 5, 6
+{
+	Offset 2, 3
+	Patch "BLUDA0", 0, 0
+	{
+		Translation Desaturate, 31
+		Style Translucent
+	}
+}

--- a/textures.txt
+++ b/textures.txt
@@ -181,6 +181,36 @@ Graphic "CIRCLEBG", 400, 400
 {
 	Patch "medical/patches/circlebg.png", 0, 0
 }
+
+Graphic "UASBLUDC0", 12, 11
+{
+	Offset 7, 6
+	Patch "BLUDC0", 0, 0
+	{
+		Translation Desaturate, 31
+		Style Translucent
+	}
+}
+
+Graphic "UASBLUDB0", 8, 8
+{
+	Offset 4, 4
+	Patch "BLUDB0", 0, 0
+	{
+		Translation Desaturate, 31
+		Style Translucent
+	}
+}
+
+Graphic "UASBLUDA0", 5, 6
+{
+	Offset 2, 3
+	Patch "BLUDA0", 0, 0
+	{
+		Translation Desaturate, 31
+		Style Translucent
+	}
+}
 Sprite "UGSID0", 48, 48
 {
 	XScale 2.500


### PR DESCRIPTION
Makes wounds and blood droplets use the player's blood colour for its coloring.
Additionally, I updated the bandage's wound icons to be the same as the visual wounds. (they also use the player's blood colour)

### Technical changes
In order to get the visual wound particles to properly tint to the player's blood colour, I had to create the following textures `UASBLUDA0`, `UASBLUDB0`, `UASBLUDC0`.
They are basically the same as the normal BLUD textures, just desaturated to be greyscale for the tinting to work properly.
The wound rendering also now uses `STYLE_Shaded` instead of `STYLE_Normal`, as the latter rendering style doesn't seem to tint that well.
Unfortunately, `STYLE_Shaded` seems to apply a lot of transparency to the texture, so the alpha is multiplied by 2 to make it more visible. (unless there's no texture being used)
As for the bandage's wound icons, it now uses different BLUD textures depending on the size of the wound (like visual wounds), and now uses the player's `BloodTranslation`. (if only particles took translations as an argument :'])


Preview:
![image](https://github.com/caligari87/Ugly-as-Sin/assets/32709291/f802f481-2bd6-4f6a-9094-76f4fe756431)
(yellow blood with `HDTestSkin`)