### PR TITLE
medical: buff trauma kit when operating on others

### DIFF
--- a/medical/module/traumakit/traumakit_biofoam.zsc
+++ b/medical/module/traumakit/traumakit_biofoam.zsc
@@ -54,10 +54,17 @@ extend class UaS_TraumaKit {
 					frandom[uas_tk](0,5) +
 					frandom[uas_tk](0,10)) / 2;
 
+				// slightly more efficient healing when operating on others
+				double fillIncrease = 0;
+				if (mti.patient != owner) {
+					check = max(check - frandom[uas_tk](0.1, 5), 0);
+					fillIncrease = frandom[uas_tk](0.1, 0.2);
+				}
+
 				// remove some tissue damage
 				if (check < mti.currentWound.cavity) {
 					mti.patient.A_StartSound("misc/bulletflesh",CHAN_BODY, CHANF_DEFAULT, 0.2);
-					mti.currentWound.cavity = max(mti.currentWound.cavity - frandom(0.1, 0.4), 0);
+					mti.currentWound.cavity = max(mti.currentWound.cavity - frandom[uas_tk](0.1, 0.4) - fillIncrease, 0);
 					//if(random[uas_tk](0,5)) { PlaySkinSound(SKINSOUND_GRUNT,"*grunt"); }
 					mti.patient.A_MuzzleClimb(
 						(frandom[uas_tk](-.1,.1),frandom[uas_tk](-.1,.1)),

--- a/medical/module/traumakit/traumakit_biofoam.zsc
+++ b/medical/module/traumakit/traumakit_biofoam.zsc
@@ -55,7 +55,7 @@ extend class UaS_TraumaKit {
 					frandom[uas_tk](0,10)) / 2;
 
 				// slightly more efficient healing when operating on others
-				if (mti.patient != owner) { check = max(check - frandom[uas_tk](0.1, 5), 0); }
+				if (mti.patient != owner) { check = max(check - frandom[uas_tk](0.1, 2.5), 0); }
 
 				// remove some tissue damage
 				if (check < mti.currentWound.cavity) {

--- a/medical/module/traumakit/traumakit_biofoam.zsc
+++ b/medical/module/traumakit/traumakit_biofoam.zsc
@@ -55,16 +55,12 @@ extend class UaS_TraumaKit {
 					frandom[uas_tk](0,10)) / 2;
 
 				// slightly more efficient healing when operating on others
-				double fillIncrease = 0;
-				if (mti.patient != owner) {
-					check = max(check - frandom[uas_tk](0.1, 5), 0);
-					fillIncrease = frandom[uas_tk](0.1, 0.2);
-				}
+				if (mti.patient != owner) { check = max(check - frandom[uas_tk](0.1, 5), 0); }
 
 				// remove some tissue damage
 				if (check < mti.currentWound.cavity) {
 					mti.patient.A_StartSound("misc/bulletflesh",CHAN_BODY, CHANF_DEFAULT, 0.2);
-					mti.currentWound.cavity = max(mti.currentWound.cavity - frandom[uas_tk](0.1, 0.4) - fillIncrease, 0);
+					mti.currentWound.cavity = max(mti.currentWound.cavity - frandom[uas_tk](0.1, 0.4), 0);
 					//if(random[uas_tk](0,5)) { PlaySkinSound(SKINSOUND_GRUNT,"*grunt"); }
 					mti.patient.A_MuzzleClimb(
 						(frandom[uas_tk](-.1,.1),frandom[uas_tk](-.1,.1)),

--- a/medical/module/traumakit/traumakit_forceps.zsc
+++ b/medical/module/traumakit/traumakit_forceps.zsc
@@ -61,9 +61,11 @@ extend class UaS_TraumaKit {
 			string result;
 
 			if (mti.currentWound.obstructed > 0 && remove > minimum) {
+				int totalRemove = remove;
+				if (mti.patient != owner) { totalRemove += random[uas_tk](2, 8); }
 				result = ExtractionMessage();
 				mti.patient.A_StartSound("misc/bulletflesh",CHAN_BODY);
-				mti.currentWound.obstructed = max(mti.currentWound.obstructed - remove, 0);
+				mti.currentWound.obstructed = max(mti.currentWound.obstructed - totalRemove, 0);
 				//mti.patient.damagemobj(owner,owner,1,"staples");
 			}
 			else { result = Stringtable.Localize("$UI_TRK_FORCEPS_PROBEWOUND"); }

--- a/medical/module/traumakit/traumakit_saline.zsc
+++ b/medical/module/traumakit/traumakit_saline.zsc
@@ -43,6 +43,11 @@ extend class UaS_TraumaKit {
 					random[uas_tk](0,75) +
 					random[uas_tk](0,100)) / 2;
 
+				// somewhat increase clean chance if someone else is doing it
+				if (mti.patient != owner) {
+					check = max(check - random[uas_tk](1, 10), 0);
+				}
+
 				if (mti.currentWound.inpain(5)) {
 					weaponstatus[TK_HOLD] = -5;
 					mti.currentWound.inpain(35);

--- a/medical/module/traumakit/traumakit_saline.zsc
+++ b/medical/module/traumakit/traumakit_saline.zsc
@@ -44,9 +44,7 @@ extend class UaS_TraumaKit {
 					random[uas_tk](0,100)) / 2;
 
 				// somewhat increase clean chance if someone else is doing it
-				if (mti.patient != owner) {
-					check = max(check - random[uas_tk](1, 10), 0);
-				}
+				if (mti.patient != owner) { check = max(check - random[uas_tk](1, 10), 0); }
 
 				if (mti.currentWound.inpain(5)) {
 					weaponstatus[TK_HOLD] = -5;

--- a/medical/module/traumakit/traumakit_stapler.zsc
+++ b/medical/module/traumakit/traumakit_stapler.zsc
@@ -30,6 +30,7 @@ extend class UaS_TraumaKit {
 			else {
 				//PlaySkinSound(SKINSOUND_GRUNT,"*grunt");
 				weaponstatus[TK_HOLD] = 15;
+				if (mti.patient != owner) { weaponstatus[TK_HOLD] = int(ceil(weaponstatus[TK_HOLD] * 0.5)); }
 			}
 			mti.patient.A_MuzzleClimb(
 				(frandom[uas_tk](-1,1),frandom[uas_tk](-1,1)),

--- a/medical/module/traumakit/traumakit_sutures.zsc
+++ b/medical/module/traumakit/traumakit_sutures.zsc
@@ -23,7 +23,8 @@ extend class UaS_TraumaKit {
 		if ((owner.player.cmd.buttons & BT_ATTACK) && (weaponstatus[TK_HOLD] == 0)) {
 			if (!HandleStrip()) { return; }
 			owner.A_StartSound("bandage/rustle",CHAN_BODY,CHANF_OVERLAP);
-			weaponstatus[TK_HOLD] = 35;
+			if (mti.patient == owner) { weaponstatus[TK_HOLD] = 35; }
+			else { weaponstatus[TK_HOLD] = 25; }
 		}
 
 		// finish suture

--- a/medical/module/traumakit/traumakit_sutures.zsc
+++ b/medical/module/traumakit/traumakit_sutures.zsc
@@ -23,8 +23,8 @@ extend class UaS_TraumaKit {
 		if ((owner.player.cmd.buttons & BT_ATTACK) && (weaponstatus[TK_HOLD] == 0)) {
 			if (!HandleStrip()) { return; }
 			owner.A_StartSound("bandage/rustle",CHAN_BODY,CHANF_OVERLAP);
-			if (mti.patient == owner) { weaponstatus[TK_HOLD] = 35; }
-			else { weaponstatus[TK_HOLD] = 25; }
+			weaponstatus[TK_HOLD] = 35;
+			if (mti.patient != owner) { weaponstatus[TK_HOLD] = int(ceil(weaponstatus[TK_HOLD] * 0.5)); }
 		}
 
 		// finish suture

--- a/medical/readme.md
+++ b/medical/readme.md
@@ -26,5 +26,7 @@ The wound will only start to heal up once it becomes green in the wounds list.
 
 Note: If the wound you're operating on is bandaged, you can hold Fire to rip it off. (or AltFire in the bandage tool)
 
+Fun fact: If you're operating on someone else, you're more likely to be a bit more efficient! (trust me it makes sense)
+
 ## Credits
  - bunyear/Tapwave: Made the trauma kit tool sprites


### PR DESCRIPTION
Basically buffs the trauma kit for coop usage.
Here are the following changes (only when operating on someone else):
- Saline and Biofoam has a slightly higher chance to not fail (which makes them a bit faster)
- Suture and stapler has a 50% cooldown reduction
- Forceps removes a bit more obstructions per removal

tl;dr: every trauma kit tool is somewhat faster except for scalpels and anesthetics

also currently a draft because it needs more testing from people that actually have someone to play coop with