### PR TITLE
traumakit: remove CheckStrip check from HandleStrip

### DIFF
--- a/medical/module/traumakit/traumakit.zsc
+++ b/medical/module/traumakit/traumakit.zsc
@@ -134,7 +134,6 @@ class UaS_TraumaKit : UaS_MedicalTool {
 		bool isBandaged = (mti.currentWound && mti.currentWound.patched > 0.);
 		let blockinv = HDWoundFixer.CheckCovered(mti.patient, CHECKCOV_CHECKBODY);
 		if (blockinv) { itemname = blockinv.GetTag(); }
-		else if (!HDPlayerPawn.CheckStrip(mti.patient, mti.patient, false)) { itemname = Stringtable.Localize("$UI_TRK_WORNLAYERS"); }
 		else if (isBandaged) { itemname = Stringtable.Localize("$UI_TRK_BANDAGE"); }
 		else { return true; }
 


### PR DESCRIPTION
Fixes backpack blocking trauma kit and also because `CheckCovered()` already checks for blocking items.
This should bring it more in line with what wornlayer the Second Flesh tool allows.

note: also removes `striptime` preventing the trauma kit from operating, but i don't think that's a bad change... (also second flesh already ignores `striptime` so...) 