### PR TITLE
Add focus spot to lasers

### DIFF
--- a/laserlight/module/laser.zsc
+++ b/laserlight/module/laser.zsc
@@ -13,6 +13,7 @@ class UaS_LaserLightModule : HDWeapon {
 	FSpawnParticleParams LP, FP;
 	transient cvar beams;
 	transient cvar laserpref, lasercolorpref, lightpref;
+	double avgdist;
 
 	double lastangle, lastpitch;
 	vector3 lastpos, lastvel;
@@ -357,6 +358,7 @@ class UaS_LaserLightModule : HDWeapon {
 		LP.Lifetime = 1;
 		LP.SizeStep = 0;
 		LP.FadeStep = -1;
+		LP.StartAlpha = 1.0;
 		LP.Flags = SPF_FULLBRIGHT|SPF_REPLACE;
 		LP.Texture = TexMan.CheckForTexture ("glstuff/glpart.png");
 
@@ -380,7 +382,7 @@ class UaS_LaserLightModule : HDWeapon {
 			PlayerPawn plr = players[consoleplayer].mo;
 			PortableLiteAmp nvg = PortableLiteAmp(plr.FindInventory("PortableLiteAmp"));
 			if (nvg && nvg.worn) {
-				//sizefactor *= clamp(nvg.amplitude * 0.1, 1, 3);
+				sizefactor *= clamp(nvg.amplitude * 0.1, 1, 3);
 				if (nvg.amplitude > 0) { LaserAlpha = 1.0; }
 			}
 		}
@@ -411,61 +413,65 @@ class UaS_LaserLightModule : HDWeapon {
 
 		// Max Length of Laser Beam
 		double maxLen = laserTrace.distance - laserTrace.HitDir.length();
+		avgdist = (avgdist*0.95)+(maxLen*0.05);
 
 		// Calculate player's position relative to the laser
 		vector3 laserVector = laserTrace.HitLocation - emitter.pos;
 		vector3 playerVector = players[consoleplayer].mo.pos - emitter.pos;
 		if (laserVector.length()==0.0) {laserVector += (0.01,0.01,0.01);}
 		double playerLinePos = (playerVector dot laserVector) / (laserVector dot laserVector);
-		playerLinePos = clamp(playerLinePos, 0.0, 1.0);
+		//playerLinePos = clamp(playerLinePos, 0.0, 1.0);
 		playerLinePos *= maxLen; //Actual distance along laser in mapunits
-		playerLinePos += 16*sin(getage()*2);
 
-		// Set some useful limits
-		double stepMax = 1000.0;
-		double stepMin = 0.25;
-		double spotRadius = 128; // "radius" of near beam spot
+		
+		double fadeLen = HDCONST_ONEMETRE*2;
+		double jitter,drawpos;
+		int maxLoops = clamp((avgdist/HDCONST_ONEMETRE)*2,5,60);
+		int pspawns=0;
+		double sizefade;
 
-		// int pspawns = 0;
-		double incr = 0.1;
-		for (double f = 0; f <= maxLen; f=f+incr) {
-			LP.Pos = emitter.pos + (oldpvec * f) + pold;
-			LP.Vel = (pvoff * f) - pold;
-			LP.Size = sizefactor * frandom[llm](0.75,1.25);
+		for (int i = 0; i < maxLoops; i++) {
+			jitter=(frandom[llmbeam](-1,1)
+				+frandom[llmbeam](-1,1)
+				+frandom[llmbeam](-1,1)
+				+frandom[llmbeam](-1,1))/4;
+			
+			// draw starting beam
+			drawpos=0+(jitter*fadeLen);
+			if (drawpos>=0 && drawpos<=maxLen) {
+				pspawns+=DrawLaserParticle(drawpos,sizefactor,oldpvec,pold,pvoff);
+			}
 
-			// Increase density at ends
-			double laserFactor = sin((f / maxLen) * 180) * (maxLen * 0.0075);
+			// draw ending beam
+			drawpos=maxLen-(jitter*fadeLen);
+			if (drawpos>=0 && drawpos<=maxLen) {
+				pspawns+=DrawLaserParticle(drawpos,sizefactor,oldpvec,pold,pvoff);
+			}
 
-			// Calculate density for player
-			double distDelta = abs(f - playerLinePos); // distance from draw position to player intersect
-			double playerFactor = distDelta / spotRadius; // make the "focus" smaller
-			double finalFactor = min(laserFactor, playerFactor); // pick the smaller increment value between the beam curve and player spot
+			// draw spot near player
+			drawpos=clamp(playerLinePos,
+				fadeLen, maxLen-(fadeLen));
+			drawpos+=(jitter*fadeLen);
+			if (drawpos>=0 && drawpos<=maxLen) {
+				pspawns+=DrawLaserParticle(drawpos,sizefactor,oldpvec,pold,pvoff);
+			}
 
-			// set the increment
-			incr = finalFactor; // * stepMax;
-			incr *= frandom[llm](0.1,16);
-			incr = clamp(incr, stepMin, stepMax);
-
-			// Calculate simulated atmospheric density (pseudo-perlin?)
-			// https://www.desmos.com/calculator/ihnnq7pdjt
-			double alph = 1.0;
-			// double alph = (
-			// 	(sin(LP.Pos.X) + sin(LP.Pos.Y) + sin(LP.Pos.Z)) +
-			// 	(sin(LP.Pos.X*10) + sin(LP.Pos.Y*10) + sin(LP.Pos.Z*10)) +
-			// 	(sin(LP.Pos.X*.5) + sin(LP.Pos.Y*.1) + sin(LP.Pos.Z*.5)) +
-			// 	sin(f+getage()));
-			// alph += max(1-incr,0);
-			// alph = clamp(alph, 0, 1);
-
-			// actually spawn particle
-			LP.StartAlpha = alph * LaserAlpha;
-			Level.SpawnParticle(LP);
-			// pspawns++;
+			// fill in rest of beam.
+			for (int j=0; j<3; j++) {
+				drawpos=frandom[llmbeam](0,maxLen);
+				pspawns+=DrawLaserParticle(drawpos,sizefactor,oldpvec,pold,pvoff);
+			}
 		}
+
+		// debugging
+		//if(level.time % 10 == 0) { console.printf("particles "..pspawns.." loops "..maxLoops.. " avgdist "..avgdist/HDCONST_ONEMETRE); }
+
+		// Draw ending particle glow
+		LP.Pos = emitter.pos + (oldpvec * maxLen) + pold;
+		LP.Vel = (pvoff * maxLen) - pold;
 		LP.Size = 1; LP.StartAlpha = 1*LaserAlpha; Level.SpawnParticle(LP);
 		LP.Size *= 4; LP.StartAlpha = 0.25*LaserAlpha; Level.SpawnParticle(LP);
 		LP.Size *= 4; LP.StartAlpha = 0.125*LaserAlpha; Level.SpawnParticle(LP);
-		// console.printf("particles "..pspawns);
 
 		//Bounce Light
 		if (!lbounce && owner is 'HDPlayerPawn') { lbounce = UaS_LLM_BounceLight(actor.spawn("UaS_LLM_BounceLight", laserTrace.HitLocation, false)); }
@@ -476,6 +482,23 @@ class UaS_LaserLightModule : HDWeapon {
 		}
 	}
 
+	int DrawLaserParticle(double dp, double sf, vector3 opv, vector3 po, vector3 pvo) {
+		//DrawLaserParticle(drawpos,oldpvec,pold,pvoff);
+		LP.Size = sf * sizefade(dp);
+		LP.Pos = emitter.pos + (opv * dp) + po;
+		LP.Vel = (pvo * dp) - po;
+		Level.SpawnParticle(LP);
+		return 1;
+	}
+
+	double sizefade(double dp) {
+		double a = sin(dp*6+getage());
+		double b = sin(dp*3-getage()*3);
+		double c = sin(dp+getage()*6);
+		double d = 0.5*(a*b*c);
+		return 1+abs(d);
+	}
+	
 	//override int getsbarnum(int flags){ return mode; }
 
 	override inventory CreateTossable(int amt) {


### PR DESCRIPTION
Resolves #262 

This PR modifies the lasers to add a "focus" spot on the beam, nearest to the player's position. This allows lasers to be drawn with significantly fewer particles while still providing good visual feedback when the beam is near a player. 

https://github.com/user-attachments/assets/72269390-7e89-4406-8e37-0570539738c2

