### PR TITLE
Hunger Service: Provide setters for player levels

### DIFF
--- a/hunger/module/hunger_service.zsc
+++ b/hunger/module/hunger_service.zsc
@@ -1,7 +1,7 @@
 class UaS_HungerStatus : Service {
 	// Returns -1 on any invalid condition
 	override int GetInt(String request, string stringArg, int intArg, double doubleArg, Object objectArg) {
-		// Do casting and nullchecks for player and respirator
+		// Do casting and nullchecks for player and hunger tracker
 		let p = HDPlayerPawn(objectArg); if (!p) return -1;
 		let r = UaS_HungerTracker(p.FindInventory("UaS_HungerTracker")); if (!r) return -1;
 
@@ -11,10 +11,33 @@ class UaS_HungerStatus : Service {
 		if (request ~== "Sick") { return int(r.sick); }
 		return -1;
 	}
+
+	override string GetString(String request, string stringArg, int intArg, double doubleArg, Object objectArg) {
+		// Do casting and nullchecks for player and hunger tracker
+		let p = HDPlayerPawn(objectArg); if (!p) return -1;
+		let r = UaS_HungerTracker(p.FindInventory("UaS_HungerTracker")); if (!r) return -1;
+
+		// Process the request
+		// example call:
+		// string retmessage = string(HungerStatus.GetString("SetEnergy", intArg:2000, objectArg:players[pnum].mo));
+		if (request ~== "SetEnergy") {
+			r.energy = intArg; return string.format("Set energy to "..r.energy); }
+		if (request ~== "SetHydro") {
+			r.hydro = intArg; return string.format("Set hydration to "..r.hydro); }
+		if (request ~== "SetPendingEnergy") {
+			r.pending_calories = intArg; return string.format("Set pending calories to "..r.pending_calories); }
+		if (request ~== "SetPendingHydro") {
+			r.pending_fluid = intArg; return string.format("Set pending fluid to "..r.pending_fluid); }
+		if (request ~== "SetSick") { 
+			r.sick = intArg; return string.format("Set sickness to "..r.sick); }
+
+		// Error
+		return "Invalid set request for UaS_Hunger";
+	}
 	
 	// Returns -1 on any invalid condition
 	override int GetIntUI(String request, string stringArg, int intArg, double doubleArg, Object objectArg) {
-		// Do casting and nullchecks for player and respirator
+		// Do casting and nullchecks for player and hunger tracker
 		let p = HDPlayerPawn(objectArg); if (!p) return -1;
 		let r = UaS_HungerTracker(p.FindInventory("UaS_HungerTracker")); if (!r) return -1;
 

--- a/hunger/module/hunger_service.zsc
+++ b/hunger/module/hunger_service.zsc
@@ -14,8 +14,8 @@ class UaS_HungerStatus : Service {
 
 	override string GetString(String request, string stringArg, int intArg, double doubleArg, Object objectArg) {
 		// Do casting and nullchecks for player and hunger tracker
-		let p = HDPlayerPawn(objectArg); if (!p) return -1;
-		let r = UaS_HungerTracker(p.FindInventory("UaS_HungerTracker")); if (!r) return -1;
+		let p = HDPlayerPawn(objectArg); if (!p) return "Player object not found";
+		let r = UaS_HungerTracker(p.FindInventory("UaS_HungerTracker")); if (!r) return "Hunger tracker not found";
 
 		// Process the request
 		// example call:


### PR DESCRIPTION
Example usage to set a player's energy levels:
```csharp
// example implementation
// Set player 0 to energy level 2000 
ServiceIterator i = ServiceIterator.Find("UaS_HungerStatus");
service HungerStatus;
HDPlayerPawn PlayerPointer = players[0].mo;
while (HungerStatus = i.Next()) {
	string retmessage = string(HungerStatus.GetString("SetEnergy", intArg:2000, objectArg:PlayerPointer));
	console.printf(retmessage);
	return energy;
}
```

Untested as I unfortunately don't have my engine set up at the moment. Feedback appreciated.